### PR TITLE
Add BER-encoding and decoding. Minor bug fixes. Add MIT license.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /test/ecc/curves/.DS_Store
 .DS_Store
 .DS_Store
+scratch.lisp

--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014, 2016 Kamran Riaz Khan (krkhan)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cl-ecc.asd
+++ b/cl-ecc.asd
@@ -8,8 +8,9 @@
   :author "Chream"
   :license "Specify license here"
   :depends-on (#:ironclad
+               #:alexandria
                #:iterate
-               #:alexandria)
+               #:asn.1)
   :serial t
   :components ((:module "ecc"
                         :serial t

--- a/ecc/ecdsa.lisp
+++ b/ecc/ecdsa.lisp
@@ -75,8 +75,9 @@
                  (u2 (mul-mod w r n))
                  (pt (add-points ec (mul-point ec g u1) (mul-point ec pub u2)))
                  (x (x pt)))
-            (assert (= (mod x n) r))
-            t)))))
+            (if (= (mod x n) r) ;; FIXME. Add error condition.
+                t
+                nil))))))
 
 (defun ecdsa-gen-priv ()
   "Function.

--- a/ecc/package.lisp
+++ b/ecc/package.lisp
@@ -19,9 +19,11 @@
    :ecdsa-verify-sig
    :ecdsa-sig-equalp
    :ecdsa-gen-pub
-
+   :ecdsa-gen-priv
+   :ecdsa-ber-encode
+   :ecdsa-ber-decode
    ;; reader functions
-   :x :y :key :version-byte :r :s :a :b :p :g :n :h
+   :x :y :key :version-byte :r :s :a :b :p :g :n :h :bytes
 
    ;; classes
    :ECDH-Private-Key

--- a/test/suites/ecdsa-suite.lisp
+++ b/test/suites/ecdsa-suite.lisp
@@ -7,8 +7,21 @@
                                    "test/keys/ECDSA-pairs.key" cl-ecc::*source-directory*)))
 
 (define-test ecc-tests::ecdsa-key-gen-test
-    (:tags ('external interface ecdsa keygen))
+    (:tags '(external interface ecdsa keygen))
   (iterate (for (key value) in-hashtable *ecdsa-key-table*)
            (let ((calc-key (key (ecdsa-gen-pub *secp256k1* (make-instance 'ECDSA-Private-Key :key key)))))
              (assert-equal (integer-length value) (integer-length calc-key))
              (assert-equal value calc-key))))
+
+(define-test ecc-tests::ber-decode
+    (:tags '(external interface ecdsa asn.1))
+  (let* ((privkey (ecdsa-gen-priv))
+         (msg (make-instance 'ECDSA-Message-hash :hash 12345676543234567876543))
+         (sig (ecdsa-gen-sig *secp256k1* msg privkey 1)))
+    (assert-typep '(simple-array (unsigned-byte 8) (*))
+                  (ecdsa-ber-encode sig))
+    (assert-typep 'ECDSA-Signature
+                  (ecdsa-ber-decode (ecdsa-ber-encode sig)))
+    (assert-equality #'ecdsa-sig-equalp
+                     (ecdsa-gen-sig *secp256k1* msg privkey 1)
+                     (ecdsa-ber-decode (ecdsa-ber-encode sig)))))


### PR DESCRIPTION
I have added BER-encoding to the signatures as this a standard way of encoding signatures over the wire. Will add DER-encoding when I have time. DER-encoding is the stricter encoding style often used for ecc, but so far I have no problems with just BER-encoding/decoding it.

Also added a MIT license.
